### PR TITLE
Bug: Past orders not displaying

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,4 +5,24 @@
         "--django-settings-module=bangazon.settings",
         "--max-line-length=120"
     ],
+    "workbench.colorCustomizations": {
+        "activityBar.activeBackground": "#ab307e",
+        "activityBar.background": "#ab307e",
+        "activityBar.foreground": "#e7e7e7",
+        "activityBar.inactiveForeground": "#e7e7e799",
+        "activityBarBadge.background": "#25320e",
+        "activityBarBadge.foreground": "#e7e7e7",
+        "commandCenter.border": "#e7e7e799",
+        "sash.hoverBorder": "#ab307e",
+        "statusBar.background": "#832561",
+        "statusBar.foreground": "#e7e7e7",
+        "statusBarItem.hoverBackground": "#ab307e",
+        "statusBarItem.remoteBackground": "#832561",
+        "statusBarItem.remoteForeground": "#e7e7e7",
+        "titleBar.activeBackground": "#832561",
+        "titleBar.activeForeground": "#e7e7e7",
+        "titleBar.inactiveBackground": "#83256199",
+        "titleBar.inactiveForeground": "#e7e7e799"
+    },
+    "peacock.color": "#832561",
 }

--- a/bangazonapi/models/order.py
+++ b/bangazonapi/models/order.py
@@ -8,3 +8,7 @@ class Order(models.Model):
     customer = models.ForeignKey(Customer, on_delete=models.DO_NOTHING,)
     payment_type = models.ForeignKey(Payment, on_delete=models.DO_NOTHING, null=True)
     created_date = models.DateField(default="0000-00-00",)
+
+    @property
+    def total_price (self):
+        return sum(item.product.price for item in self.lineitems.all())

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -147,7 +147,7 @@ class Orders(ViewSet):
             ]
         """
         customer = Customer.objects.get(user=request.auth.user)
-        orders = Order.objects.filter(customer=customer)
+        orders = Order.objects.filter(customer=customer).exclude(payment_type_id=None)
 
         payment = self.request.query_params.get('payment_id', None)
         if payment is not None:

--- a/bangazonapi/views/order.py
+++ b/bangazonapi/views/order.py
@@ -8,12 +8,14 @@ from rest_framework import status
 from rest_framework.decorators import action
 from bangazonapi.models import Order, Payment, Customer, Product, OrderProduct
 from .product import ProductSerializer
+from .paymenttype import PaymentSerializer
 
 
 class OrderLineItemSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for line items """
 
-    product = ProductSerializer(many=False)
+    product = ProductSerializer(many=False) 
+    #  this is a nested serializer
 
     class Meta:
         model = OrderProduct
@@ -28,14 +30,19 @@ class OrderSerializer(serializers.HyperlinkedModelSerializer):
     """JSON serializer for customer orders"""
 
     lineitems = OrderLineItemSerializer(many=True)
+    total_price = serializers.SerializerMethodField()
+    payment_type = PaymentSerializer(many=False)
 
+    def get_total_price (self, obj):
+        return obj.total_price
+    
     class Meta:
         model = Order
         url = serializers.HyperlinkedIdentityField(
             view_name='order',
             lookup_field='id'
         )
-        fields = ('id', 'url', 'created_date', 'payment_type', 'customer', 'lineitems')
+        fields = ('id', 'url', 'created_date', 'payment_type', 'customer', 'lineitems', 'total_price')
 
 
 class Orders(ViewSet):

--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -19,7 +19,7 @@ class ProductSerializer(serializers.ModelSerializer):
         model = Product
         fields = ('id', 'name', 'price', 'number_sold', 'description',
                   'quantity', 'created_date', 'location', 'image_path',
-                  'average_rating', 'can_be_rated', )
+                  'average_rating', 'can_be_rated', 'store_id' )
         depth = 1
 
 


### PR DESCRIPTION
Description of PR that completes issue here...

## Changes

- added decorator to order bangazonapi/models/order.py
- added product serializer to order line item serializer to produce total price
- Item 3

## Requests / Responses

If this PR contains code that defines a new request/response, or changes an existing one, please put the JSON representations here.

**Request**

GET `/order` Adds a new line item field called  "total_price" 

Responce example listed below

```
{
        "id": 1,
        "url": "http://localhost:8000/orders/1",
        "created_date": "2019-08-16",
        "payment_type": {
            "id": 1,
            "url": "http://localhost:8000/paymenttypes/1",
            "merchant_name": "Visa",
            "account_number": "24ijio68948fj8439",
            "expiration_date": "2020-01-01",
            "create_date": "2019-11-11"
        },
        "customer": "http://localhost:8000/customers/5",
        "lineitems": [],
        "total_price": 0
    },
```

## Testing

Description of how to test code...
run GET request for "http://localhost:8000/orders/1" and insure the ""total_price"" field has been added. 

- [ ] Run migrations
- [ ] Run test suite
- [ ] Seed database


## Related Issues

- Fixes #35 