### PR TITLE
final correction for number sold logic

### DIFF
--- a/bangazonapi/views/product.py
+++ b/bangazonapi/views/product.py
@@ -269,7 +269,7 @@ class Products(ViewSet):
 
         if number_sold is not None:
             def sold_filter(product):
-                if product.number_sold <= int(number_sold):
+                if product.number_sold >= int(number_sold):
                     return True
                 return False
 


### PR DESCRIPTION
Description of PR that completes issue here...

Bug fix where logic was corrected for filtering number_sold in the browser

## Changes

- operation change under Product View

## Requests / Responses

**Request**

GET http://localhost:8000/products?direction=asc&number_sold=1&


**Response**

```json
[
    {
        "id": 45,
        "name": "Optima",
        "price": 1655.15,
        "number_sold": 1,
        "description": "2008 Kia",
        "quantity": 3,
        "created_date": "2019-05-21",
        "location": "Toronto",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 0,
        "store_id": 1
    },
    {
        "id": 50,
        "name": "Golf",
        "price": 653.59,
        "number_sold": 2,
        "description": "1994 Volkswagen",
        "quantity": 4,
        "created_date": "2019-07-10",
        "location": "Berlin",
        "image_path": "http://localhost:8000/media/products/vehicle.png",
        "average_rating": 3.25,
        "store_id": 1
    }
]



## Testing

- Filter by number on the filter section in the browser



## Related Issues

- Fixes #7 